### PR TITLE
Implement method documentation tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,18 @@ You can always write your own template that will provide the desired functionali
 If you think that your template might be useful to others, please consider adding it to our [template repository](https://github.com/hexdigest/gowrap/tree/master/templates).
 
 The structure of information passed to templates is documented with the [TemplateInputs](https://godoc.org/github.com/hexdigest/gowrap/generator#TemplateInputs) struct.
+
+## Documentation Tags
+
+Interface methods can be preceded by documentation comments with gowrap tags to define a map that a template can use to modify its code generation.  
+For example, this might be used to indicate to a template generating logging decorators that password values should not be logged:
+```
+//+gowrap: {"Log":{"pass":"xxxxx"}}
+Login(user string, pass string) (err error)
+```
+A template could access the map via the Docs property of the method node, for example:
+```
+{{$loghints := $method.Docs.Log}}
+...
+{{$logval := index $loghints $param.Name}}
+```

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -244,7 +244,8 @@ func processInterface(fs *token.FileSet, it *ast.InterfaceType, types []*ast.Typ
 		switch v := field.Type.(type) {
 		case *ast.FuncType:
 			var method *Method
-			method, err = NewMethod(field.Names[0].Name, v, printer.New(fs, types, typesPrefix))
+
+			method, err = NewMethod(field, v, printer.New(fs, types, typesPrefix))
 			if err == nil {
 				methods[field.Names[0].Name] = *method
 				continue

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -392,6 +392,48 @@ func Test_processInterface(t *testing.T) {
 			want1:   methodsList{},
 			wantErr: false,
 		},
+		{
+			name: "method with valid doc",
+			args: args{
+				fs: token.NewFileSet(),
+				it: &ast.InterfaceType{Methods: &ast.FieldList{List: []*ast.Field{
+					{
+						Names: []*ast.Ident{{Name: "methodName"}},
+						Type: &ast.FuncType{Params: &ast.FieldList{}},
+						Doc: &ast.CommentGroup{
+							List: []*ast.Comment{
+								{
+									Text: `// Non-tag comment`,
+								},
+								{
+									Text: `//+gowrap: {"Key":"Value"}`,
+								},
+							},
+						},
+				}}}},
+			},
+			want1:   methodsList{"methodName": Method{Name: "methodName", Params: []Param{}, Docs:map[string]interface{}{"Key":"Value"}}},
+			wantErr: false,
+		},
+		{
+			name: "method with invalid doc",
+			args: args{
+				fs: token.NewFileSet(),
+				it: &ast.InterfaceType{Methods: &ast.FieldList{List: []*ast.Field{
+					{
+						Names: []*ast.Ident{{Name: "methodName"}},
+						Type: &ast.FuncType{Params: &ast.FieldList{}},
+						Doc: &ast.CommentGroup{
+							List: []*ast.Comment{
+								{
+									Text: `//+gowrap: {"Key":"BadJson..."`,
+								},
+							},
+						},
+					}}}},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -74,7 +74,7 @@ func FromDir(fs *token.FileSet, dir string, filter filterFunc) (*ast.Package, er
 		filter = NoTests
 	}
 
-	pkgs, err := parseDir(fs, dir, filter, parser.DeclarationErrors)
+	pkgs, err := parseDir(fs, dir, filter, parser.DeclarationErrors | parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A documentation tag defines a JSON representation of a map that is available to a template via the Docs property of a Method node.
There are no constraints on how it is used but, for example, it could define hints about how/if parameters/results should be logged.