### PR TITLE
Produce regular read-write files

### DIFF
--- a/cmd_generate.go
+++ b/cmd_generate.go
@@ -88,7 +88,7 @@ func (gc *GenerateCommand) Run(args []string, stdout io.Writer) error {
 		return err
 	}
 
-	return gc.filepath.WriteFile(gc.outputFile, buf.Bytes(), 0777)
+	return gc.filepath.WriteFile(gc.outputFile, buf.Bytes(), 0664)
 }
 
 var (


### PR DESCRIPTION
This patch changes generated file permissions to u=rw,g=rw,o=r,
these are default file permissions for unix file system. There
is no reason to produce executable source files.