### PR TITLE
Auto-register prometheus metrics

### DIFF
--- a/templates/prometheus
+++ b/templates/prometheus
@@ -1,7 +1,8 @@
 import (
-  "sync"
   "time"
+
   "github.com/prometheus/client_golang/prometheus"
+  "github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 {{ $decorator := (or .Vars.DecoratorName (printf "%sWithPrometheus" .Interface.Name)) }}
@@ -13,19 +14,16 @@ type {{$decorator}} struct {
   instanceName string
 }
 
-var {{down .Interface.Name}}DurationSummaryVec = prometheus.NewSummaryVec(
+var {{down .Interface.Name}}DurationSummaryVec = promauto.NewSummaryVec(
   prometheus.SummaryOpts{
     Name: "{{down .Interface.Name}}_duration_seconds",
     Help: "{{down .Interface.Name}} runtime duration and result",
     MaxAge: time.Minute,
-  }, 
+  },
   []string{"instance_name", "method", "result"})
-
-var {{down .Interface.Name}}DurationSummaryOnce = &sync.Once{}
 
 // New{{.Interface.Name}}WithPrometheus returns an instance of the {{.Interface.Type}} decorated with prometheus summary metric
 func New{{$decorator}}(base {{.Interface.Type}}, instanceName string) {{$decorator}} {
-  {{down .Interface.Name}}DurationSummaryOnce.Do(func() { prometheus.MustRegister({{down .Interface.Name}}DurationSummaryVec) })
   return {{$decorator}} {
     base: base,
     instanceName: instanceName,
@@ -43,10 +41,10 @@ func New{{$decorator}}(base {{.Interface.Type}}, instanceName string) {{$decorat
             result = "error"
           }
 
-				  {{down $.Interface.Name}}DurationSummaryVec.WithLabelValues(_d.instanceName, "{{$method.Name}}", result).Observe(time.Since(_since).Seconds())
+          {{down $.Interface.Name}}DurationSummaryVec.WithLabelValues(_d.instanceName, "{{$method.Name}}", result).Observe(time.Since(_since).Seconds())
         }()
       {{else}}
-				defer {{down $.Interface.Name}}DurationSummaryVec.WithLabelValues(_d.instanceName, "{{$method.Name}}", "ok").Observe(time.Since(_since).Seconds())
+        defer {{down $.Interface.Name}}DurationSummaryVec.WithLabelValues(_d.instanceName, "{{$method.Name}}", "ok").Observe(time.Since(_since).Seconds())
       {{end}}
     {{$method.Pass "_d.base."}}
   }

--- a/templates_tests/interface_with_prometheus.go
+++ b/templates_tests/interface_with_prometheus.go
@@ -8,10 +8,10 @@ package templatestests
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // TestInterfaceWithPrometheus implements TestInterface interface with all methods wrapped
@@ -21,7 +21,7 @@ type TestInterfaceWithPrometheus struct {
 	instanceName string
 }
 
-var testinterfaceDurationSummaryVec = prometheus.NewSummaryVec(
+var testinterfaceDurationSummaryVec = promauto.NewSummaryVec(
 	prometheus.SummaryOpts{
 		Name:   "testinterface_duration_seconds",
 		Help:   "testinterface runtime duration and result",
@@ -29,11 +29,8 @@ var testinterfaceDurationSummaryVec = prometheus.NewSummaryVec(
 	},
 	[]string{"instance_name", "method", "result"})
 
-var testinterfaceDurationSummaryOnce = &sync.Once{}
-
 // NewTestInterfaceWithPrometheus returns an instance of the TestInterface decorated with prometheus summary metric
 func NewTestInterfaceWithPrometheus(base TestInterface, instanceName string) TestInterfaceWithPrometheus {
-	testinterfaceDurationSummaryOnce.Do(func() { prometheus.MustRegister(testinterfaceDurationSummaryVec) })
 	return TestInterfaceWithPrometheus{
 		base:         base,
 		instanceName: instanceName,


### PR DESCRIPTION
This patch uses "promauto" package to register metrics instead of
manual syncrhonized registration with "sync" package.