### PR TITLE
Fixing "printChan" method for bidirectional channels

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -88,7 +88,7 @@ func (p *Printer) printArray(a *ast.ArrayType) (string, error) {
 }
 
 var chanTypes = map[ast.ChanDir]string{
-	ast.SEND & ast.RECV: "chan ",
+	ast.SEND | ast.RECV: "chan ",
 	ast.SEND:            "chan<- ",
 	ast.RECV:            "<-chan ",
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -258,7 +258,7 @@ func TestPrinter_printChan(t *testing.T) {
 		},
 		{
 			name: "bidirectional channel",
-			ch:   &ast.ChanType{Value: &ast.Ident{Name: "Exported"}, Dir: ast.SEND & ast.RECV},
+			ch:   &ast.ChanType{Value: &ast.Ident{Name: "Exported"}, Dir: ast.SEND | ast.RECV},
 			init: func(t minimock.Tester) *Printer {
 				return &Printer{
 					fs:    token.NewFileSet(),
@@ -845,7 +845,7 @@ func TestPrinter_PrintType(t *testing.T) {
 		},
 		{
 			name: "chan type",
-			node: &ast.ChanType{Value: &ast.Ident{Name: "string"}},
+			node: &ast.ChanType{Value: &ast.Ident{Name: "string"}, Dir: ast.SEND | ast.RECV},
 			init: func(t minimock.Tester) *Printer {
 				return &Printer{
 					fs:  token.NewFileSet(),

--- a/templates_tests/interface.go
+++ b/templates_tests/interface.go
@@ -2,9 +2,10 @@ package templatestests
 
 import "context"
 
-//TestInterface is used to test templates
+// TestInterface is used to test templates
 type TestInterface interface {
 	F(ctx context.Context, a1 string, a2 ...string) (result1, result2 string, err error)
 	NoError(string) string
 	NoParamsOrResults()
+	Channels(chA chan bool, chB chan<- bool, chanC <-chan bool)
 }

--- a/templates_tests/interface_with_circuitbreaker.go
+++ b/templates_tests/interface_with_circuitbreaker.go
@@ -34,6 +34,8 @@ func NewTestInterfaceWithCircuitBreaker(base TestInterface, consecutiveErrors in
 	}
 }
 
+// Channels implements TestInterface
+
 // F implements TestInterface
 func (_d *TestInterfaceWithCircuitBreaker) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	_d._lock.RLock()

--- a/templates_tests/interface_with_circuitbreaker_test.go
+++ b/templates_tests/interface_with_circuitbreaker_test.go
@@ -40,6 +40,9 @@ func (c *consecutiveErrorsImpl) NoError(string) string {
 func (c *consecutiveErrorsImpl) NoParamsOrResults() {
 }
 
+func (c *consecutiveErrorsImpl) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+}
+
 func TestTestInterfaceWithCircuitBreaker_F(t *testing.T) {
 	ctx := context.Background()
 

--- a/templates_tests/interface_with_fallback.go
+++ b/templates_tests/interface_with_fallback.go
@@ -25,6 +25,30 @@ func NewTestInterfaceWithFallback(interval time.Duration, impls ...TestInterface
 	return TestInterfaceWithFallback{implementations: impls, interval: interval}
 }
 
+// Channels implements TestInterface
+func (_d TestInterfaceWithFallback) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	type _resultStruct struct {
+	}
+
+	var _ch = make(chan _resultStruct, 0)
+
+	var _ticker = time.NewTicker(_d.interval)
+	defer _ticker.Stop()
+	for _i := 0; _i < len(_d.implementations); _i++ {
+		go func(_impl TestInterface) {
+			_impl.Channels(chA, chB, chanC)
+			_ch <- _resultStruct{}
+		}(_d.implementations[_i])
+		select {
+		case <-_ch:
+			return
+		case <-_ticker.C:
+		}
+	}
+
+	return
+}
+
 // F implements TestInterface
 func (_d TestInterfaceWithFallback) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	type _resultStruct struct {

--- a/templates_tests/interface_with_fallback_test.go
+++ b/templates_tests/interface_with_fallback_test.go
@@ -45,6 +45,8 @@ func (f *testImpl) NoError(s string) string {
 
 func (f *testImpl) NoParamsOrResults() {}
 
+func (f *testImpl) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {}
+
 func TestTestInterfaceWithFallback_F(t *testing.T) {
 	t.Run("one implementation success", func(t *testing.T) {
 		impl := &testImpl{r1: "1", r2: "2"}

--- a/templates_tests/interface_with_log.go
+++ b/templates_tests/interface_with_log.go
@@ -27,6 +27,17 @@ func NewTestInterfaceWithLogger(base TestInterface, stdout, stderr io.Writer) Te
 	}
 }
 
+// Channels implements TestInterface
+func (_d TestInterfaceWithLogger) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	_params := []interface{}{"TestInterfaceWithLogger: calling Channels with params:", chA, chB, chanC}
+	_d._stdlog.Println(_params...)
+	defer func() {
+		_d._stdlog.Println("TestInterfaceWithLogger: Channels finished")
+	}()
+	_d._base.Channels(chA, chB, chanC)
+	return
+}
+
 // F implements TestInterface
 func (_d TestInterfaceWithLogger) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	_params := []interface{}{"TestInterfaceWithLogger: calling F with params:", ctx, a1, a2}

--- a/templates_tests/interface_with_logrus.go
+++ b/templates_tests/interface_with_logrus.go
@@ -26,6 +26,19 @@ func NewTestInterfaceWithLogrus(base TestInterface, log *logrus.Entry) TestInter
 	}
 }
 
+// Channels implements TestInterface
+func (_d TestInterfaceWithLogrus) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	_d._log.WithFields(logrus.Fields(map[string]interface{}{
+		"chA":   chA,
+		"chB":   chB,
+		"chanC": chanC})).Debug("TestInterfaceWithLogrus: calling Channels")
+	defer func() {
+		_d._log.Debug("TestInterfaceWithLogrus: Channels finished")
+	}()
+	_d._base.Channels(chA, chB, chanC)
+	return
+}
+
 // F implements TestInterface
 func (_d TestInterfaceWithLogrus) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	_d._log.WithFields(logrus.Fields(map[string]interface{}{

--- a/templates_tests/interface_with_prometheus.go
+++ b/templates_tests/interface_with_prometheus.go
@@ -38,6 +38,17 @@ func NewTestInterfaceWithPrometheus(base TestInterface, instanceName string) Tes
 	}
 }
 
+// Channels implements TestInterface
+func (_d TestInterfaceWithPrometheus) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		testinterfaceDurationSummaryVec.WithLabelValues(_d.instanceName, "Channels", result).Observe(time.Since(_since).Seconds())
+	}()
+	_d.base.Channels(chA, chB, chanC)
+	return
+}
+
 // F implements TestInterface
 func (_d TestInterfaceWithPrometheus) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	_since := time.Now()

--- a/templates_tests/interface_with_ratelimit.go
+++ b/templates_tests/interface_with_ratelimit.go
@@ -40,6 +40,14 @@ func NewTestInterfaceWithRateLimit(base TestInterface, concurrentRequests int, r
 	return d
 }
 
+// Channels implements TestInterface
+func (_d *TestInterfaceWithRateLimit) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	<-_d._ticks
+
+	_d._base.Channels(chA, chB, chanC)
+	return
+}
+
 // F implements TestInterface
 func (_d *TestInterfaceWithRateLimit) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	select {

--- a/templates_tests/interface_with_robinpool.go
+++ b/templates_tests/interface_with_robinpool.go
@@ -39,6 +39,13 @@ func MustNewTestInterfaceRoundRobinPool(pool ...TestInterface) *TestInterfaceRou
 	return &TestInterfaceRoundRobinPool{pool: pool, poolSize: uint32(len(pool))}
 }
 
+// Channels implements TestInterface
+func (_d *TestInterfaceRoundRobinPool) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	_counter := atomic.AddUint32(&_d.counter, 1)
+	_d.pool[_counter%_d.poolSize].Channels(chA, chB, chanC)
+	return
+}
+
 // F implements TestInterface
 func (_d *TestInterfaceRoundRobinPool) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	_counter := atomic.AddUint32(&_d.counter, 1)

--- a/templates_tests/interface_with_syncpool.go
+++ b/templates_tests/interface_with_syncpool.go
@@ -28,6 +28,16 @@ func NewTestInterfacePool(impls ...TestInterface) TestInterfacePool {
 	return TestInterfacePool{pool: pool}
 }
 
+// Channels implements TestInterface
+func (_d TestInterfacePool) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+	_impl := <-_d.pool
+	defer func() {
+		_d.pool <- _impl
+	}()
+	_impl.Channels(chA, chB, chanC)
+	return
+}
+
 // F implements TestInterface
 func (_d TestInterfacePool) F(ctx context.Context, a1 string, a2 ...string) (result1 string, result2 string, err error) {
 	_impl := <-_d.pool

--- a/templates_tests/interface_with_timeout_test.go
+++ b/templates_tests/interface_with_timeout_test.go
@@ -27,6 +27,9 @@ func (c *timeoutsImpl) NoError(string) string {
 func (c *timeoutsImpl) NoParamsOrResults() {
 }
 
+func (c *timeoutsImpl) Channels(chA chan bool, chB chan<- bool, chanC <-chan bool) {
+}
+
 func TestTestInterfaceWithTimeout_F(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Hi,

I believe it will fix this issue https://github.com/gojuno/minimock/issues/41
The previous commit https://github.com/hexdigest/gowrap/commit/e0c4708e933c42ae3c0abc414cc4ed8391bd9767 didn't fix that. 

I've modified `chanTypes` map because of this line https://github.com/golang/go/blob/go1.14.4/src/go/parser/parser.go#L1012

I added this line
`Channels(chA chan bool, chB chan<- bool, chanC <-chan bool)` 
to the tests to make sure that it works now. Hope I didn't miss anything in terms of testing.