### PR TITLE
add twirp_error template

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ List of available templates:
   - [syncpool](https://github.com/hexdigest/gowrap/tree/master/templates/syncpool) puts several implementations of the source interface to the sync.Pool and for every method call it gets one implementation from the pool and puts it back once finished
   - [timeout](https://github.com/hexdigest/gowrap/tree/master/templates/timeout) instruments each method that accepts context with configurable timeout
   - [validate](https://github.com/hexdigest/gowrap/tree/master/templates/validate) runs `func Validate() error` method on each argument if it's present
+  - [twirp\_error](https://github.com/hexdigest/gowrap/tree/master/templates/twirp_error) inject request data into twirp.Error as metadata
   - [twirp\_validate](https://github.com/hexdigest/gowrap/tree/master/templates/twirp_validate) runs `func Validate() error` method on each argument if it's present and wraps returned error with twirp.Malformed error
   - [grpc\_validate](https://github.com/hexdigest/gowrap/tree/master/templates/grpc_validate) runs `func Validate() error` method on each argument if it's present and returns [InvalidArgument](https://github.com/grpc/grpc-go/blob/9d8d97a245af2d4bc743585418e1b4aebada0637/codes/codes.go#L49) error in case when validation failed
 

--- a/templates/twirp_error
+++ b/templates/twirp_error
@@ -1,0 +1,44 @@
+import (
+  "github.com/twitchtv/twirp"
+)
+
+{{ $decorator := (or .Vars.DecoratorName (printf "%sWithTwirpError" .Interface.Name)) }}
+
+// {{$decorator}} implements {{.Interface.Type}} interface instrumented with arguments validation
+type {{$decorator}} struct {
+  {{.Interface.Type}}
+}
+
+// New{{$decorator}} returns {{$decorator}}
+func New{{$decorator}} (base {{.Interface.Type}}) {{$decorator}} {
+  return {{$decorator}} {
+    {{.Interface.Name}}: base,
+  }
+}
+
+{{range $method := .Interface.Methods}}
+  // {{$method.Name}} implements {{$.Interface.Type}}
+  func (_d {{$decorator}}) {{$method.Declaration}} {
+    {{- if $method.ReturnsError}}
+      {{range $param := $method.Params}}
+        {{if not ( and $method.AcceptsContext (eq $param.Name "ctx")) }}
+          defer injectRequestDataToError({{$param.Name}} ,&err)
+        {{end}}
+      {{end}}
+    {{end}}
+    {{$method.Pass (printf "_d.%s." $.Interface.Name) }}
+  }
+{{end}}
+
+func injectRequestDataToError(req interface{}, perr *error) {
+	err := *perr
+	if err != nil {
+		twerr, ok := err.(twirp.Error)
+		if !ok {
+			twerr = twirp.InternalErrorWith(err)
+		}
+
+		jsonReq, _ := json.Marshal(req)
+		*perr = twerr.WithMeta("request", string(jsonReq))
+	}
+}

--- a/templates_tests/interface_with_twirp_error.go
+++ b/templates_tests/interface_with_twirp_error.go
@@ -1,0 +1,47 @@
+package templatestests
+
+// DO NOT EDIT!
+// This code is generated with http://github.com/hexdigest/gowrap tool
+// using ../templates/twirp_error template
+
+//go:generate gowrap gen -p github.com/hexdigest/gowrap/templates_tests -i InterfaceWithTwirpError -t ../templates/twirp_error -o interface_with_twirp_error.go
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/twitchtv/twirp"
+)
+
+// InterfaceWithTwirpErrorWithTwirpError implements InterfaceWithTwirpError interface instrumented with arguments validation
+type InterfaceWithTwirpErrorWithTwirpError struct {
+	InterfaceWithTwirpError
+}
+
+// NewInterfaceWithTwirpErrorWithTwirpError returns InterfaceWithTwirpErrorWithTwirpError
+func NewInterfaceWithTwirpErrorWithTwirpError(base InterfaceWithTwirpError) InterfaceWithTwirpErrorWithTwirpError {
+	return InterfaceWithTwirpErrorWithTwirpError{
+		InterfaceWithTwirpError: base,
+	}
+}
+
+// Method implements InterfaceWithTwirpError
+func (_d InterfaceWithTwirpErrorWithTwirpError) Method(ctx context.Context, r *MethodRequest) (mp1 *MethodResponse, err error) {
+
+	defer injectRequestDataToError(r, &err)
+
+	return _d.InterfaceWithTwirpError.Method(ctx, r)
+}
+
+func injectRequestDataToError(req interface{}, perr *error) {
+	err := *perr
+	if err != nil {
+		twerr, ok := err.(twirp.Error)
+		if !ok {
+			twerr = twirp.InternalErrorWith(err)
+		}
+
+		jsonReq, _ := json.Marshal(req)
+		*perr = twerr.WithMeta("request", string(jsonReq))
+	}
+}

--- a/templates_tests/interface_with_twirp_error_test.go
+++ b/templates_tests/interface_with_twirp_error_test.go
@@ -1,0 +1,47 @@
+package templatestests
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/twitchtv/twirp"
+	"testing"
+)
+
+type WithTwirpError struct{}
+
+type MethodRequest struct {
+	Foo string `json:"foo"`
+}
+
+type MethodResponse struct{}
+
+//TestInterface is used to test templates
+type InterfaceWithTwirpError interface {
+	Method(ctx context.Context, r *MethodRequest) (*MethodResponse, error)
+}
+
+func (v *WithTwirpError) Method(_ context.Context, req *MethodRequest) (*MethodResponse, error) {
+	if req.Foo != "bar" {
+		return nil, fmt.Errorf("foo != bar")
+	}
+	return nil, nil
+}
+
+func TestInterfaceWithTwirpError_Method(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		wrapped := NewInterfaceWithTwirpErrorWithTwirpError(&WithTwirpError{})
+		_, err := wrapped.Method(context.Background(), &MethodRequest{Foo: "bar"})
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		wrapped := NewInterfaceWithTwirpErrorWithTwirpError(&WithTwirpError{})
+		_, err := wrapped.Method(context.Background(), &MethodRequest{Foo: "invalid"})
+		require.Error(t, err)
+		twirpErr, ok := err.(twirp.Error)
+		require.True(t, ok)
+		require.Equal(t, twirp.Internal, twirpErr.Code())
+		require.Equal(t, "{\"foo\":\"invalid\"}", twirpErr.Meta("request"))
+	})
+}


### PR DESCRIPTION
Added template twirp_error. Which inject request data into twirp.Error as metadata. 
This allows ServerHooks.Error to access the request data for more detailed logging.