### PR TITLE
Added TemplateInputInterface MethodsList method

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -87,6 +87,15 @@ type TemplateInputInterface struct {
 	Methods map[string]Method
 }
 
+//MethodsList returns list of method information
+func (i TemplateInputInterface) MethodsList() []Method {
+	methods := make([]Method, 0, len(i.Methods))
+	for _, v := range i.Methods {
+		methods = append(methods, v)
+	}
+	return methods
+}
+
 type methodsList map[string]Method
 
 //Options of the NewGenerator constructor


### PR DESCRIPTION
This method allow iterate by methods with indexes.
Use in templates example:
```
{{range $i, $method := .Interface.MethodsList}}
// something: arr[{{$i}}].Do()
{{end}}
```
Range over map not provided indexing in go templates.
