### PR TITLE
Load source package with imports

### DIFF
--- a/pkg/package.go
+++ b/pkg/package.go
@@ -14,7 +14,7 @@ var errPackageNotFound = errors.New("package not found")
 
 // Load loads package by its import path
 func Load(path string) (*packages.Package, error) {
-	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles}
+	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This way the generator won't have to load the same packages multiple times while processing interfaces.

With the project I'm working on at the moment, gowrap takes almost 30 seconds to load an interface. After profiling with pprof, I noticed most of that time is spend inside `pkg.Load`. 

![image](https://user-images.githubusercontent.com/169434/151675618-3557e9a1-7faf-4360-8eba-db86dee6732b.png)


In the current implementation while, processing interfaces, for every method and embedded interface, the same packages are loaded multiple times. If the package is loaded with imports and import paths are searched from the first loaded package struct the same interface is loaded in less than two seconds.