### PR TITLE
Clarify the docs on circuitbreaker template

### DIFF
--- a/templates/circuitbreaker
+++ b/templates/circuitbreaker
@@ -17,8 +17,8 @@ type {{$decorator}} struct {
   _closesAt *time.Time
 }
 
-// New{{$decorator}} breakes a circuit after consecutiveErrors of errors and opens the circuit again after openInterval of time.
-// If after openInterval first method call results in error we close open again.
+// New{{$decorator}} breakes a circuit after consecutiveErrors of errors and closes the circuit again after openInterval of time.
+// If, after openInterval, the first method call results in error we open and close again.
 func New{{$decorator}}(base {{.Interface.Type}}, consecutiveErrors int, openInterval time.Duration) (*{{$decorator}}) {
   return &{{$decorator}}{
     {{.Interface.Name}}: base, 
@@ -28,8 +28,8 @@ func New{{$decorator}}(base {{.Interface.Type}}, consecutiveErrors int, openInte
 }
 
 {{range $method := .Interface.Methods}}
-  // {{$method.Name}} implements {{$.Interface.Type}}
   {{- if $method.ReturnsError}}
+    // {{$method.Name}} implements {{$.Interface.Type}}
     func (_d *{{$decorator}}) {{$method.Declaration}} {
       _d._lock.RLock()
 


### PR DESCRIPTION
The use of opens/closes and opened/closed is mixed up in the docs.

The wrapped implementation is called when the circuit is closed, so it breaks when it fails (goes to opened state) and _closes_ after some time (goes to closed state again)