### PR TITLE
Feat: template file relative to git root path

### DIFF
--- a/loader/gitpath.go
+++ b/loader/gitpath.go
@@ -1,0 +1,15 @@
+package loader
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func gitRootPath() (string, error) {
+	path, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(path)), nil
+}

--- a/loader/gitpath_test.go
+++ b/loader/gitpath_test.go
@@ -1,0 +1,36 @@
+package loader
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_gitRootPath(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "last element should be gowrap",
+			want: "gowrap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gitRootPath()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, filepath.Base(got))
+		})
+	}
+}
+
+func mockGitRootPath(mockPath string) func() (string, error) {
+	return func() (string, error) {
+		return mockPath, nil
+	}
+}


### PR DESCRIPTION
Adds support to define template source as relative to git root path.
Which makes it possible to define the template source as
`a/b/c/t.template` instead of
`../../../t.template`