### PR TITLE
Allow overlapping methods

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -404,18 +404,19 @@ func processSelector(fs *token.FileSet, currentPackage *packages.Package, se *as
 	return methods, err
 }
 
-//mergeMethods merges two methods list
-func mergeMethods(ml1, ml2 methodsList) (methodsList, error) {
-	if ml1 == nil || ml2 == nil {
-		return ml1, nil
+//mergeMethods merges two methods list. Retains overlapping methods from the
+//parent list
+func mergeMethods(methods, embeddedMethods methodsList) (methodsList, error) {
+	if methods == nil || embeddedMethods == nil {
+		return methods, nil
 	}
 
-	result := make(methodsList, len(ml1)+len(ml2))
-	for k, v := range ml1 {
-		result[k] = v
+	result := make(methodsList, len(methods)+len(embeddedMethods))
+	for name, signature := range embeddedMethods {
+		result[name] = signature
 	}
 
-	for name, signature := range ml2 {
+	for name, signature := range methods {
 		result[name] = signature
 	}
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -404,10 +404,7 @@ func processSelector(fs *token.FileSet, currentPackage *packages.Package, se *as
 	return methods, err
 }
 
-var errDuplicateMethod = errors.New("embedded interface has same method")
-
-//mergeMethods merges two methods list, if there is a duplicate method name
-//errDuplicateMethod is returned
+//mergeMethods merges two methods list
 func mergeMethods(ml1, ml2 methodsList) (methodsList, error) {
 	if ml1 == nil || ml2 == nil {
 		return ml1, nil
@@ -419,10 +416,6 @@ func mergeMethods(ml1, ml2 methodsList) (methodsList, error) {
 	}
 
 	for name, signature := range ml2 {
-		if _, ok := ml1[name]; ok {
-			return nil, errors.Wrap(errDuplicateMethod, name)
-		}
-
 		result[name] = signature
 	}
 

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -197,6 +197,27 @@ func Test_mergeMethods(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "duplicate methods should return outer method",
+			args: args{
+				ml1: methodsList{
+					"method": Method{
+						Doc: []string{"outer"},
+					},
+				},
+				ml2: methodsList{
+					"method": Method{
+						Doc: []string{"inner"},
+					},
+				},
+			},
+			wantErr: false,
+			want1: methodsList{
+				"method": {
+					Doc: []string{"outer"},
+				},
+			},
+		},
+		{
 			name: "success",
 			args: args{
 				ml1: methodsList{

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -197,21 +197,6 @@ func Test_mergeMethods(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "duplicate method",
-			args: args{
-				ml1: methodsList{
-					"method": Method{},
-				},
-				ml2: methodsList{
-					"method": Method{},
-				},
-			},
-			wantErr: true,
-			inspectErr: func(err error, t *testing.T) {
-				assert.Equal(t, errDuplicateMethod, errors.Cause(err))
-			},
-		},
-		{
 			name: "success",
 			args: args{
 				ml1: methodsList{


### PR DESCRIPTION
Since golang allows overlapping methods in embedded interfaces, do not fail if overlapping methods are found when merging embedded interfaces.

This will unfortunately pull Doc and Comment fields from an arbitrary overlapping method, but in my opinion that's better than returning an error.