### PR TITLE
Create the path that the output file will be generated

### DIFF
--- a/cmd_generate.go
+++ b/cmd_generate.go
@@ -93,6 +93,10 @@ func (gc *GenerateCommand) Run(args []string, stdout io.Writer) error {
 		return err
 	}
 
+	if err := os.MkdirAll(filepath.Dir(gc.outputFile), os.ModePerm); err != nil {
+		return err
+	}
+
 	return gc.filepath.WriteFile(gc.outputFile, buf.Bytes(), 0664)
 }
 


### PR DESCRIPTION
Currently, if we want to generate the output in another directory, we need to have
```
//go:generate mkdir -p decorator
//go:generate gowrap gen -p . -i Auth -t template/foo.tmpl -o ./decorator/auth.go
```

With this PR, we could get rid of the first `go:generate mkdir`
```
//go:generate gowrap gen -p . -i Auth -t template/foo.tmpl -o ./decorator/auth.go
```