### PR TITLE
Fix: add all types from the package

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -361,7 +361,6 @@ func iterateFiles(p *ast.Package, name string) (selectedType *ast.TypeSpec, impo
 				if ts.Name.Name == name {
 					selectedType = ts
 					imports = f.Imports
-					return
 				}
 			}
 		}


### PR DESCRIPTION
Removed `return` in `iterateFiles` method, as it could lead to situation when not all types from target package are imported.
If some types are not imported, `printIdent` in `printer/printer.go` will fail to make a comparison and will not add `typesPrefix` to the type name. 