### PR TITLE
Update README.md with new install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ With GoWrap you can easily add metrics, tracing, fallbacks, pools, and many othe
 ![demo](https://github.com/hexdigest/gowrap/blob/master/gowrap.gif)
 
 ## Installation
-
+### CLI
+```
+go install github.com/hexdigest/gowrap/cmd/gowrap@latest
+```
+### As module
 ```
 go get -u github.com/hexdigest/gowrap/cmd/gowrap
 ```


### PR DESCRIPTION
Running the current install command outside a go module returns the error below, so updated the readme with the new command.

```
$ go get -u github.com/hexdigest/gowrap/cmd/gowrap 
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```