### PR TITLE
Support of union and type approximation in generics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: ./bin/golangci-lint
 
 .PHONY:
 test:
-	 go test -race ./...
+	 go test -race -v ./...
 
 .PHONY:
 generate: ./bin/gowrap ./bin/minimock


### PR DESCRIPTION
I discovered that in last version of minimock (v3.3.7) when we upped version of gowrap we broke generation of interfaces with generic unions. It happened because of this pr https://github.com/hexdigest/gowrap/pull/84 . So here i introduce support of generic types with union, e.g.

```go
type genericInlineUnionWithManyTypes[T int | float64 | string] interface {
	Name(T)
}
```

and with type approximations , е.g.

```go
type generic[T ~int] interface {
	Name(T)
}
```

and their combinations.

I also removed panic of unsupported generic type, because if we encounter unsupported generic type we should be able at least to finish generation without panicing.