### PR TITLE
fix: avoid double loading of source package

### DIFF
--- a/cmd_generate.go
+++ b/cmd_generate.go
@@ -13,9 +13,10 @@ import (
 	"unicode"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/pkg/errors"
+
 	"github.com/hexdigest/gowrap/generator"
 	"github.com/hexdigest/gowrap/pkg"
-	"github.com/pkg/errors"
 )
 
 // GenerateCommand implements Command interface
@@ -151,6 +152,7 @@ func (gc *GenerateCommand) getOptions() (*generator.Options, error) {
 	}
 
 	options.SourcePackage = sourcePackage.PkgPath
+	options.SourcePackageInstance = sourcePackage // Pass the loaded package
 	options.BodyTemplate, options.HeaderVars["Template"], err = gc.loadTemplate(outputFileDir)
 
 	return &options, err

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -3,13 +3,12 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
-	"sort"
-	"strings"
-
 	"go/ast"
 	"go/token"
 	"io"
+	"path/filepath"
+	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -106,6 +105,9 @@ type Options struct {
 	//SourcePackage is an import path or a relative path of the package that contains the source interface
 	SourcePackage string
 
+	//SourcePackageInstance is the already loaded package (optional)
+	SourcePackageInstance *packages.Package
+
 	//SourcePackageAlias is an import selector defauls is source package name
 	SourcePackageAlias string
 
@@ -181,9 +183,15 @@ func NewGenerator(options Options) (*Generator, error) {
 
 	fs := token.NewFileSet()
 
-	srcPackage, err := pkg.Load(options.SourcePackage)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to load source package")
+	var srcPackage *packages.Package
+	// Use the preloaded package if available, only load if not
+	if options.SourcePackageInstance != nil {
+		srcPackage = options.SourcePackageInstance
+	} else {
+		srcPackage, err = pkg.Load(options.SourcePackage)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load source package")
+		}
 	}
 
 	dstPackagePath := filepath.Dir(options.OutputFile)


### PR DESCRIPTION
Hey.
Thank you for the super helpful package. 
We are heavily using it in github.com/cadence-workflow/cadence for wrapper generations. One thing though, in our case it is a bit slow.
I was investigating possibilities - and found that sourcePackage is read 2 times:
1. inside getOptions() function
2. inside NewGenerator consructor

Removing this double loading saves around 10% of the execution time.

This should be a noop for other cases.
