### PR TITLE
fix: Create an alias around ast.Package to fix lint

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -3,13 +3,12 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
-	"sort"
-	"strings"
-
 	"go/ast"
 	"go/token"
 	"io"
+	"path/filepath"
+	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -137,7 +136,7 @@ type methodsList map[string]Method
 type processInput struct {
 	fileSet        *token.FileSet
 	currentPackage *packages.Package
-	astPackage     *ast.Package
+	astPackage     *pkg.Package
 	targetName     string
 	genericParams  genericParams
 }
@@ -427,7 +426,7 @@ func findSourcePackage(ident *ast.Ident, imports []*ast.ImportSpec) string {
 	return ""
 }
 
-func iterateFiles(p *ast.Package, name string) (selectedType *ast.TypeSpec, imports []*ast.ImportSpec, types []*ast.TypeSpec) {
+func iterateFiles(p *pkg.Package, name string) (selectedType *ast.TypeSpec, imports []*ast.ImportSpec, types []*ast.TypeSpec) {
 	for _, f := range p.Files {
 		if f != nil {
 			for _, ts := range typeSpecs(f) {
@@ -444,7 +443,7 @@ func iterateFiles(p *ast.Package, name string) (selectedType *ast.TypeSpec, impo
 }
 
 func typeSpecs(f *ast.File) []*ast.TypeSpec {
-	result := []*ast.TypeSpec{}
+	var result []*ast.TypeSpec
 
 	for _, decl := range f.Decls {
 		if gd, ok := decl.(*ast.GenDecl); ok && gd.Tok == token.TYPE {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -9,11 +9,13 @@ import (
 	"text/template"
 	"time"
 
-	minimock "github.com/gojuno/minimock/v3"
+	"github.com/gojuno/minimock/v3"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/hexdigest/gowrap/pkg"
 )
 
 func Test_unquote(t *testing.T) {
@@ -478,7 +480,7 @@ func Test_findTarget(t *testing.T) {
 			name: "not found",
 			args: args{
 				input: processInput{
-					astPackage: &ast.Package{},
+					astPackage: &pkg.Package{},
 				},
 			},
 			wantErr: true,
@@ -490,7 +492,7 @@ func Test_findTarget(t *testing.T) {
 			name: "found",
 			args: args{
 				input: processInput{
-					astPackage: &ast.Package{Files: map[string]*ast.File{
+					astPackage: &pkg.Package{Files: map[string]*ast.File{
 						"file.go": {
 							Decls: []ast.Decl{&ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{&ast.TypeSpec{
 								Name: &ast.Ident{Name: "Interface"},
@@ -506,13 +508,14 @@ func Test_findTarget(t *testing.T) {
 			name: "found interface alias",
 			args: args{
 				input: processInput{
-					astPackage: &ast.Package{
+					astPackage: &pkg.Package{
 						Files: map[string]*ast.File{
 							"file.go": {
 								Decls: []ast.Decl{&ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{&ast.TypeSpec{
 									Name: &ast.Ident{Name: "InterfaceAlias"},
 									Type: &ast.Ident{
 										Name: "Interface",
+										//nolint:staticcheck // SA1019, this is an internal object that is still used by ast library.
 										Obj: &ast.Object{
 											Decl: &ast.TypeSpec{
 												Type: &ast.InterfaceType{},
@@ -531,7 +534,7 @@ func Test_findTarget(t *testing.T) {
 			name: "found interface alias on exported type",
 			args: args{
 				input: processInput{
-					astPackage: &ast.Package{
+					astPackage: &pkg.Package{
 						Files: map[string]*ast.File{
 							"file.go": {
 								Decls: []ast.Decl{&ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{&ast.TypeSpec{
@@ -583,7 +586,7 @@ func Test_findTarget(t *testing.T) {
 			name: "found interface alias on exported type with named package",
 			args: args{
 				input: processInput{
-					astPackage: &ast.Package{
+					astPackage: &pkg.Package{
 						Files: map[string]*ast.File{
 							"file.go": {
 								Decls: []ast.Decl{&ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{&ast.TypeSpec{

--- a/pkg/package.go
+++ b/pkg/package.go
@@ -12,6 +12,11 @@ import (
 
 var errPackageNotFound = errors.New("package not found")
 
+type Package struct {
+	Name  string
+	Files map[string]*ast.File
+}
+
 // Load loads package by its import path
 func Load(path string) (*packages.Package, error) {
 	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps}
@@ -32,7 +37,7 @@ func Load(path string) (*packages.Package, error) {
 }
 
 // AST returns package's abstract syntax tree
-func AST(fs *token.FileSet, p *packages.Package) (*ast.Package, error) {
+func AST(fs *token.FileSet, p *packages.Package) (*Package, error) {
 	dir := Dir(p)
 
 	pkgs, err := parser.ParseDir(fs, dir, nil, parser.DeclarationErrors|parser.ParseComments)
@@ -41,10 +46,13 @@ func AST(fs *token.FileSet, p *packages.Package) (*ast.Package, error) {
 	}
 
 	if ap, ok := pkgs[p.Name]; ok {
-		return ap, nil
+		return &Package{
+			Name:  p.Name,
+			Files: ap.Files,
+		}, nil
 	}
 
-	return &ast.Package{Name: p.Name}, nil
+	return &Package{Name: p.Name}, nil
 }
 
 // Dir returns absolute path of the package in a filesystem


### PR DESCRIPTION
Fixing an issue of golangci-lint failing on usage of deprecated struct ast.Package.
As far as I can see, the usage could be avoided by simply introducing a minimal structure with Name and files.
Though the test scenario still requires the usage of ast.Object, I've added a comment to ignore the issue in the test.
