### PR TITLE
OpenTelemetry template: use the interface name without the package as the default span name prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 /dist
 /.gh_token
 /gowrap
+
+# Editors
+.idea

--- a/templates/opentelemetry
+++ b/templates/opentelemetry
@@ -1,9 +1,9 @@
 import (
     "context"
 
+    _codes "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel"
     "go.opentelemetry.io/otel/attribute"
-    _codes "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
 )
 

--- a/templates/opentelemetry
+++ b/templates/opentelemetry
@@ -3,7 +3,7 @@ import (
 
     "go.opentelemetry.io/otel"
     "go.opentelemetry.io/otel/attribute"
-    "go.opentelemetry.io/otel/codes"
+    _codes "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
 )
 
@@ -41,7 +41,7 @@ func (_d {{$decorator}}) {{$method.Declaration}} {
       _d._spanDecorator(_span, {{$method.ParamsMap}}, {{$method.ResultsMap}})
     }{{- if $method.ReturnsError}} else if err != nil {
       _span.RecordError(err)
-      _span.SetStatus(codes.Error, err.Error())
+      _span.SetStatus(_codes.Error, err.Error())
       _span.SetAttributes(
         attribute.String("event", "error"),
         attribute.String("message", err.Error()),

--- a/templates/opentelemetry
+++ b/templates/opentelemetry
@@ -3,6 +3,7 @@ import (
 
     "go.opentelemetry.io/otel"
     "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
 )
 
@@ -40,6 +41,7 @@ func (_d {{$decorator}}) {{$method.Declaration}} {
       _d._spanDecorator(_span, {{$method.ParamsMap}}, {{$method.ResultsMap}})
     }{{- if $method.ReturnsError}} else if err != nil {
       _span.RecordError(err)
+      _span.SetStatus(codes.Error, err.Error())
       _span.SetAttributes(
         attribute.String("event", "error"),
         attribute.String("message", err.Error()),

--- a/templates/opentelemetry
+++ b/templates/opentelemetry
@@ -7,8 +7,9 @@ import (
 )
 
 {{ $decorator := (or .Vars.DecoratorName (printf "%sWithTracing" .Interface.Name)) }}
+{{ $spanNameType := (or .Vars.SpanNamePrefix .Interface.Name) }}
 
-// {{$decorator}} implements {{.Interface.Type}} interface instrumented with opentracing spans
+// {{$decorator}} implements {{.Interface.Name}} interface instrumented with open telemetry spans
 type {{$decorator}} struct {
   {{.Interface.Type}}
   _instance string
@@ -31,9 +32,9 @@ func New{{$decorator}} (base {{.Interface.Type}}, instance string, spanDecorator
 
 {{range $method := .Interface.Methods}}
   {{if $method.AcceptsContext}}
-    // {{$method.Name}} implements {{$.Interface.Type}}
+    // {{$method.Name}} implements {{$.Interface.Name}}
 func (_d {{$decorator}}) {{$method.Declaration}} {
-  ctx, _span := otel.Tracer(_d._instance).Start(ctx, "{{$.Interface.Type}}.{{$method.Name}}")
+  ctx, _span := otel.Tracer(_d._instance).Start(ctx, "{{$spanNameType}}.{{$method.Name}}")
   defer func() {
     if _d._spanDecorator != nil {
       _d._spanDecorator(_span, {{$method.ParamsMap}}, {{$method.ResultsMap}})


### PR DESCRIPTION
This PR take care of #101.

Take for example this interface : 
```
package mypackage

type MyInterface interface {
	MyMethod()
}
```

When the interface and the generated file are in the same package, the span names start with the interface name like this `MyInterface.MyMethod`. This PR doesn't change that.

When the interface and the generated file are NOT in the same package, the span name had an additional prefix that include the interface package. It used to be `mypackage.MyInterface.MyMethod` but after #92 it became `_sourceMypackage.MyInterface.MyMethod`. 

With this PR, the default span name is always the same whether the interface and the generated file are in the same package or not i.e. `MyInterface.MyMethod`. 

This is also possible to change default span name prefix with the `SpanNamePrefix` variable. For `SpanNamePrefix=NewInterface`, the generated span name would be `NewInterface.MyMethod`. If you want to include the package name, include it in the variable: `SpanNamePrefix="mypackage.MyInterface"`.




