### PR TITLE
Replace errors.New with fmt.Errorf for joined error list

### DIFF
--- a/templates/fallback
+++ b/templates/fallback
@@ -1,4 +1,5 @@
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -76,7 +77,7 @@ func New{{$decorator}}(interval time.Duration, impls ...{{.Interface.Type}}) {{$
                   _next <- struct{}{}
                   _errorsList = append(_errorsList, _res.err.Error())
                   if len(_errorsList) == len(_d.implementations) {
-                    err =  fmt.Errorf(strings.Join(_errorsList, ";"))
+                    err =  errors.New(strings.Join(_errorsList, ";"))
                     return
                   }
                 {{else}}


### PR DESCRIPTION
Also needs to fix go vet errors since go 1.25:
.....go:75:22: non-constant format string in call to fmt.Errorf