### PR TITLE
Correction of usage errors.Wrap instead of errors.Wrapf

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -678,7 +678,7 @@ func findImportPathForName(name string, imports []*ast.ImportSpec, currentPackag
 		}
 	}
 
-	return "", errors.Wrapf(errUnknownSelector, name)
+	return "", errors.Wrap(errUnknownSelector, name)
 }
 
 func unquote(s string) string {


### PR DESCRIPTION
The [master](https://github.com/hexdigest/gowrap/actions/runs/19522728509/job/55889252977) build is currently failing with the following error:
```
Error: generator/generator.go:681:46: printf: non-constant format string in call to github.com/pkg/errors.Wrapf (govet)
	return "", errors.Wrapf(errUnknownSelector, name)
	                                            ^
make: *** [Makefile:32: lint] Error 1
Error: Process completed with exit code 2.
```
The method uses `errors.Wrapf` instead of `errors.Wrap`
